### PR TITLE
Move region logic, set timeout

### DIFF
--- a/ds.go
+++ b/ds.go
@@ -570,6 +570,7 @@ func SetRegion(region *string) error {
 }
 
 func setRegion(region *string) {
+	log.WithField("region", *region).Debug("Setting region")
 	SetDynamoDBConfig(&aws.Config{Region: region})
 	SetKMSConfig(&aws.Config{Region: region})
 }


### PR DESCRIPTION
* Trying to fetch meta-data outside of AWS will take along time to timeout, over ride this with 5 seconds.
* Move get and set region to ds.