### PR TITLE
Fix passing encryption context for get all

### DIFF
--- a/cmd/unicreds/main.go
+++ b/cmd/unicreds/main.go
@@ -160,7 +160,7 @@ func main() {
 			printFatalError(err)
 		}
 	case cmdGetAll.FullCommand():
-		creds, err := unicreds.GetAllSecrets(dynamoTable, *cmdGetAllVersions)
+		creds, err := unicreds.GetAllSecrets(dynamoTable, *cmdGetAllVersions, encContext)
 		if err != nil {
 			printFatalError(err)
 		}
@@ -190,7 +190,7 @@ func main() {
 		if err != nil {
 			printFatalError(err)
 		}
-		creds, err := unicreds.GetAllSecrets(dynamoTable, *cmdGetAllVersions)
+		creds, err := unicreds.GetAllSecrets(dynamoTable, *cmdGetAllVersions, encContext)
 		for _, cred := range creds {
 			os.Setenv(cred.Name, cred.Secret)
 		}

--- a/ds.go
+++ b/ds.go
@@ -305,11 +305,8 @@ func ListSecrets(tableName *string, allVersions bool) ([]*Credential, error) {
 }
 
 // GetAllSecrets returns a list of all secrets
-func GetAllSecrets(tableName *string, allVersions bool) ([]*DecryptedCredential, error) {
+func GetAllSecrets(tableName *string, allVersions bool, encContext *EncryptionContextValue) ([]*DecryptedCredential, error) {
 	log.Debug("Getting all secrets")
-
-	// build an empty encryption context
-	encContext := NewEncryptionContextValue()
 
 	var items []map[string]*dynamodb.AttributeValue
 	var lastEvaluatedKey map[string]*dynamodb.AttributeValue
@@ -360,8 +357,8 @@ func GetAllSecrets(tableName *string, allVersions bool) ([]*DecryptedCredential,
 		dcred, err := decryptCredential(cred, encContext)
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
-				if awsErr.Code() == "AccessDeniedException" {
-					log.Debugf("KMS Access Denied to decrypt: %s", cred.Name)
+				if awsErr.Code() == "AccessDeniedException" || awsErr.Code() == "InvalidCiphertextException" {
+					log.Debugf("%s: %s", err, cred.Name)
 					continue
 				}
 			}
@@ -471,10 +468,10 @@ func DeleteSecret(tableName *string, name string) error {
 		_, err = dynamoSvc.DeleteItem(&dynamodb.DeleteItemInput{
 			TableName: tableName,
 			Key: map[string]*dynamodb.AttributeValue{
-				"name": &dynamodb.AttributeValue{
+				"name": {
 					S: aws.String(cred.Name),
 				},
-				"version": &dynamodb.AttributeValue{
+				"version": {
 					S: aws.String(cred.Version),
 				},
 			},
@@ -523,7 +520,17 @@ func decryptCredential(cred *Credential, encContext *EncryptionContextValue) (*D
 	}
 
 	dk, err := DecryptDataKey(wrappedKey, encContext)
-
+	if awsErr, ok := err.(awserr.Error); ok {
+		// Create reasoned responses to assist with debugging
+		if awsErr.Code() == "AccessDeniedException" {
+			log.Debugf("KMS Access Denied to decrypt: %s", cred.Name)
+			err = awserr.New("AccessDeniedException", "KMS Access Denied to decrypt", nil)
+		}
+		if awsErr.Code() == "InvalidCiphertextException" {
+			err = awserr.New("InvalidCiphertextException", "The encryption context provided "+
+				"may not match the one used when the credential was stored", nil)
+		}
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
getall was not passing encryption contexts to decrypt functions so not listing available secrets.  Also needed to handle secrets that the hmac could not be decrypted due to wrong encryption context.

tests added