### PR TITLE
add option to strip suffix/prefix from credentials before exec

### DIFF
--- a/cmd/unicreds/main_test.go
+++ b/cmd/unicreds/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/versent/unicreds"
+	"testing"
+)
+
+func TestStripFix(t *testing.T) {
+
+	testTable := []struct {
+		Prefix    []string
+		Suffix    []string
+		Delimiter string
+		Name      string
+		Result    string
+	}{
+		{[]string{}, []string{}, ".", "NO_CHANGE", "NO_CHANGE"},
+		{[]string{"PRE"}, []string{}, "_", "PRE_FIX", "FIX"},
+		{[]string{"PRE"}, []string{"FIX"}, "_", "PRE_FIX", "FIX"},
+		{[]string{""}, []string{"FIX"}, "_", "PRE_FIX", "PRE"},
+		{[]string{"PRE", "FIX"}, []string{""}, "_", "PRE_FIX", "FIX"},
+		{[]string{"PRE", "FIX"}, []string{"FIX"}, "_", "PRE_FIX_MORE", "FIX_MORE"},
+		{[]string{"PRE", "FIX"}, []string{"FIX", "MORE"}, "_", "PRE_FIX_MORE", "FIX"},
+		{[]string{"PRE_FIX"}, []string{"FIX"}, "_", "PRE_FIX_MORE", "MORE"},
+		{[]string{"PRE"}, []string{}, "_", "PRE_", "PRE_"},
+		{[]string{}, []string{"FIX"}, "_", "_FIX", "_FIX"},
+	}
+
+	for _, test := range testTable {
+		c := &unicreds.DecryptedCredential{
+			Credential: &unicreds.Credential{
+				Name: test.Name,
+			},
+		}
+		stripFix(c, test.Prefix, test.Suffix, test.Delimiter)
+		assert.Equal(t, test.Result, c.Name)
+	}
+
+}


### PR DESCRIPTION
Although encryption context allows for credentials to be "effectively" filtered they don't stop credentials from different environments with the same credential name from overwriting each other.

The common pattern to overcome this is to add an environment prefix or suffix to the credential name.   E.G. STAGING_SECRET_KEY and PROD_SECRET_KEY

This PR enables the environment variables that are injected into a command environment to have these prefixes and suffixes stripped before injection.  The actual keys remain unchanged for all other operations.

E.G. the following will strip PROD_ for the credential and just inject SECRET_KEY

unicreds exec env -D _ -P PROD

Similarly -S operates on the suffix and -D denotes the delimiter (default ".")

Tests add

Works properly with PR #59 