### PR TITLE
add support of environment variables for table and key alias

### DIFF
--- a/cmd/unicreds/main.go
+++ b/cmd/unicreds/main.go
@@ -24,8 +24,8 @@ var (
 	region  = app.Flag("region", "Configure the AWS region").Short('r').String()
 	profile = app.Flag("profile", "Configure the AWS profile").Short('p').String()
 
-	dynamoTable = app.Flag("table", "DynamoDB table.").Default("credential-store").Short('t').String()
-	alias       = app.Flag("alias", "KMS key alias.").Default("alias/credstash").Short('k').String()
+	dynamoTable = app.Flag("table", "DynamoDB table.").Default("credential-store").OverrideDefaultFromEnvar("UNICREDS_TABLE").Short('t').String()
+	alias       = app.Flag("alias", "KMS key alias.").Default("alias/credstash").OverrideDefaultFromEnvar("UNICREDS_ALIAS").Short('k').String()
 	encContext  = encryptionContext(app.Flag("enc-context", "Add a key value pair to the encryption context.").Short('E'))
 
 	// commands


### PR DESCRIPTION
This very small feature is useful for a usage inside a docker container. 