### PR TITLE
Add AssumeRole support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /package
 /stage
 dist
+unicreds

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ unicreds setup --region ap-southeast-2 --profile [yourawsprofile]
 
 To illustrate how unicreds works I made a screen recording of list, put, get and delete.
 
-![Image of screencast](docs/images/unicreds_recording.gif) 
+![Image of screencast](docs/images/unicreds_recording.gif)
 
 # usage
 
@@ -46,10 +46,11 @@ Flags:
   -j, --json                     Output results in JSON
   -r, --region=REGION            Configure the AWS region
   -p, --profile=PROFILE          Configure the AWS profile
-  -t, --table="credential-store"  
+  -R, --role=ROLE                Specify an AWS role ARN to assume
+  -t, --table="credential-store"
                                  DynamoDB table.
   -k, --alias="alias/credstash"  KMS key alias.
-  -E, --enc-context=ENC-CONTEXT ...  
+  -E, --enc-context=ENC-CONTEXT ...
                                  Add a key value pair to the encryption context.
       --version                  Show application version.
 
@@ -84,32 +85,43 @@ Commands:
 
 # examples
 
-* List secrets.
+* List secrets using default profile:
 ```
-$ unicreds -r us-west-2 -p [yourawsprofile] list
+$ unicreds -r us-west-2 list
 ```
+
+* List secrets using profile MYPROFILE in `~/.aws/credentials` (NOTE: `~/.aws/config` is only used by aws CLI, not the SDK)
+```
+$ unicreds -r us-west-2 -p MYPROFILE list
+```
+
+* List secrets using a profile, but also assuming a role:
+```
+$ unicreds -r us-west-2 -p MYPROFILE -R arn:aws:iam::123456789012:role/MYROLE list
+```
+
 * Store a login for `test123` from unicreds using the encryption context feature.
 ```
-$ unicreds -r us-west-2 -p [yourawsprofile] put test123 -E 'stack:123' testingsup
+$ unicreds -r us-west-2 put test123 -E 'stack:123' testingsup
    • stored                    name=test123 version=0000000000000000001
 ```
 
 * Retrieve a login for `test123` from unicreds using the encryption context feature.
 ```
-$ unicreds -r us-west-2 -p [yourawsprofile] get test123 -E 'stack:123'
+$ unicreds -r us-west-2 get test123 -E 'stack:123'
 testingsup
 ```
 
 * Example of a failed encryption context check.
 ```
-$ unicreds -r us-west-2 -p [yourawsprofile] get test123 -E 'stack:12'
+$ unicreds -r us-west-2 get test123 -E 'stack:12'
    ⨯ failed                    error=InvalidCiphertextException:
 	status code: 400, request id: 0fed8a0b-5ea1-11e6-b359-fd8168c3c784
 ```
 
 * Execute `env` command, all secrets are loaded as environment variables.
 ```
-$ unicreds -r us-west-2 -p [yourawsprofile] exec -- env
+$ unicreds -r us-west-2 exec -- env
 ```
 
 # references

--- a/aws_config.go
+++ b/aws_config.go
@@ -6,6 +6,8 @@ import (
 	"github.com/apex/log"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 const (
@@ -14,7 +16,7 @@ const (
 
 // SetAwsConfig configure the AWS region with a fallback for discovery
 // on EC2 hosts.
-func SetAwsConfig(region, profile *string) (err error) {
+func SetAwsConfig(region, profile *string, role *string) (err error) {
 	if region == nil {
 		// Try to get our region based on instance metadata
 		region, err = getRegion()
@@ -33,18 +35,28 @@ func SetAwsConfig(region, profile *string) (err error) {
 		return fmt.Errorf("Must provide a region flag when specifying a profile")
 	}
 
-	setAwsConfig(region, profile)
+	setAwsConfig(region, profile, role)
 	return nil
 }
 
-func setAwsConfig(region, profile *string) {
+func setAwsConfig(region, profile *string, role *string) {
 	log.WithFields(log.Fields{"region": aws.StringValue(region), "profile": aws.StringValue(profile)}).Debug("Configure AWS")
 	config := &aws.Config{Region: region}
+
 	// if a profile is supplied then just use the shared credentials provider
 	// as per docs this will look in $HOME/.aws/credentials if the filename is ""
 	if aws.StringValue(profile) != "" {
 		config.Credentials = credentials.NewSharedCredentials("", *profile)
 	}
+
+	// Are we assuming a role?
+	if aws.StringValue(role) != "" {
+		// Must request credentials from STS service and replace before passing on
+		sess := session.Must(session.NewSession(config))
+		log.WithFields(log.Fields{"role": aws.StringValue(role)}).Debug("AssumeRole")
+		config.Credentials = stscreds.NewCredentials(sess, *role)
+	}
+
 	SetDynamoDBConfig(config)
 	SetKMSConfig(config)
 }

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -9,15 +9,18 @@ import (
 
 func TestConfig(t *testing.T) {
 
-	err := SetAwsConfig(nil, nil)
+	err := SetAwsConfig(nil, nil, nil)
 	assert.Nil(t, err)
 
-	err = SetAwsConfig(aws.String(""), aws.String(""))
+	err = SetAwsConfig(aws.String(""), aws.String(""), aws.String(""))
 	assert.Nil(t, err)
 
-	err = SetAwsConfig(aws.String(""), aws.String("wolfeidau"))
+	err = SetAwsConfig(aws.String(""), aws.String("wolfeidau"), aws.String(""))
 	assert.Error(t, err)
 
-	err = SetAwsConfig(aws.String("us-west-2"), aws.String("wolfeidau"))
+	err = SetAwsConfig(aws.String("us-west-2"), aws.String("wolfeidau"), aws.String(""))
+	assert.Nil(t, err)
+
+	err = SetAwsConfig(aws.String("us-west-2"), aws.String("wolfeidau"), aws.String("role"))
 	assert.Nil(t, err)
 }

--- a/cmd/unicreds/main.go
+++ b/cmd/unicreds/main.go
@@ -23,6 +23,7 @@ var (
 
 	region  = app.Flag("region", "Configure the AWS region").Short('r').String()
 	profile = app.Flag("profile", "Configure the AWS profile").Short('p').String()
+	role    = app.Flag("role", "Specify an AWS role ARN to assume").Short('R').String()
 
 	dynamoTable = app.Flag("table", "DynamoDB table.").Default("credential-store").OverrideDefaultFromEnvar("UNICREDS_TABLE").Short('t').String()
 	alias       = app.Flag("alias", "KMS key alias.").Default("alias/credstash").OverrideDefaultFromEnvar("UNICREDS_ALIAS").Short('k').String()
@@ -79,7 +80,7 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	unicreds.SetAwsConfig(region, profile)
+	unicreds.SetAwsConfig(region, profile, role)
 
 	switch command {
 	case cmdSetup.FullCommand():


### PR DESCRIPTION
Based on the sample AssumeRole code here:
https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials/stscreds/

I've added an additional optional flag for a Role ARN.
If specified, I used the configuration (with our without a profile)
to request temporary credentials via the STS service.

These credentials are then passed to the DynamoDB and Kinesis modules.

Not really sure why a single session isn't created at the start
and passed to the other modules, but I'll leave that optimization
for another developer to fix