### PR TITLE
Fix noline print when secret contains fmt verb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 /package
 /stage
 dist
-unicreds

--- a/cmd/unicreds/main.go
+++ b/cmd/unicreds/main.go
@@ -106,7 +106,7 @@ func main() {
 			log.WithFields(log.Fields{"name": *cmdGetName, "secret": cred.Secret, "status": "success"}).Info(cred.Secret)
 		} else {
 			// Or just print, out of backwards compatibility
-			unicreds.PrintSecret(os.Stdout, cred.Secret, *cmdGetNoLine)
+			unicreds.FprintSecret(os.Stdout, cred.Secret, *cmdGetNoLine)
 		}
 
 	case cmdPut.FullCommand():

--- a/cmd/unicreds/main.go
+++ b/cmd/unicreds/main.go
@@ -210,7 +210,7 @@ func printFatalError(err error) {
 func printSecret(secret string, noline bool) {
 	log.WithField("noline", noline).Debug("print secret")
 	if noline {
-		fmt.Printf(secret)
+		fmt.Printf("%s", secret)
 	} else {
 		fmt.Println(secret)
 	}

--- a/cmd/unicreds/main.go
+++ b/cmd/unicreds/main.go
@@ -106,7 +106,7 @@ func main() {
 			log.WithFields(log.Fields{"name": *cmdGetName, "secret": cred.Secret, "status": "success"}).Info(cred.Secret)
 		} else {
 			// Or just print, out of backwards compatibility
-			unicreds.PrintSecret(cred.Secret, *cmdGetNoLine)
+			unicreds.PrintSecret(os.Stdout, cred.Secret, *cmdGetNoLine)
 		}
 
 	case cmdPut.FullCommand():

--- a/cmd/unicreds/main.go
+++ b/cmd/unicreds/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -107,7 +106,7 @@ func main() {
 			log.WithFields(log.Fields{"name": *cmdGetName, "secret": cred.Secret, "status": "success"}).Info(cred.Secret)
 		} else {
 			// Or just print, out of backwards compatibility
-			printSecret(cred.Secret, *cmdGetNoLine)
+			unicreds.PrintSecret(cred.Secret, *cmdGetNoLine)
 		}
 
 	case cmdPut.FullCommand():
@@ -205,15 +204,6 @@ func main() {
 func printFatalError(err error) {
 	log.WithError(err).Error("failed")
 	os.Exit(1)
-}
-
-func printSecret(secret string, noline bool) {
-	log.WithField("noline", noline).Debug("print secret")
-	if noline {
-		fmt.Printf("%s", secret)
-	} else {
-		fmt.Println(secret)
-	}
 }
 
 func printEncryptionContext(encContext *unicreds.EncryptionContextValue) {

--- a/cmd/unicreds/main_test.go
+++ b/cmd/unicreds/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+func ExamplePrintSecret() {
+	var printSecretTests = []struct {
+		in string
+		// must manually specify output in Example tests
+	}{
+		{"foo"},
+		{"foo."},
+		{"Foo\\"},
+		{"%"},
+		{"%%"},
+		{"%s"},
+		{"%#v"},
+	}
+
+	for _, noline := range []bool{false, true} {
+		for _, tt := range printSecretTests {
+			printSecret(tt.in, noline)
+		}
+	}
+
+	// Output:
+	// foo
+	// foo.
+	// Foo\
+	// %
+	// %%
+	// %s
+	// %#v
+	// foofoo.Foo\%%%%s%#v
+}

--- a/printer.go
+++ b/printer.go
@@ -7,7 +7,7 @@ import (
 	"github.com/apex/log"
 )
 
-func PrintSecret(w io.Writer, secret string, noline bool) {
+func FprintSecret(w io.Writer, secret string, noline bool) {
 	log.WithField("noline", noline).Debug("print secret")
 	if noline {
 		fmt.Fprintf(w, "%s", secret)

--- a/printer.go
+++ b/printer.go
@@ -2,15 +2,16 @@ package unicreds
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/apex/log"
 )
 
-func PrintSecret(secret string, noline bool) {
+func PrintSecret(w io.Writer, secret string, noline bool) {
 	log.WithField("noline", noline).Debug("print secret")
 	if noline {
-		fmt.Printf("%s", secret)
+		fmt.Fprintf(w, "%s", secret)
 	} else {
-		fmt.Println(secret)
+		fmt.Fprintln(w, secret)
 	}
 }

--- a/printer.go
+++ b/printer.go
@@ -1,0 +1,16 @@
+package unicreds
+
+import (
+	"fmt"
+
+	"github.com/apex/log"
+)
+
+func PrintSecret(secret string, noline bool) {
+	log.WithField("noline", noline).Debug("print secret")
+	if noline {
+		fmt.Printf("%s", secret)
+	} else {
+		fmt.Println(secret)
+	}
+}

--- a/printer_test.go
+++ b/printer_test.go
@@ -1,37 +1,59 @@
 package unicreds
 
 import (
-	"os"
+	"bytes"
+	"testing"
 )
 
-func ExampleFprintSecret() {
-	w := os.Stdout
+func TestFprintSecret(t *testing.T) {
+	var w bytes.Buffer
 	var printSecretTests = []struct {
 		in string
-		// must manually specify output in Example tests
 	}{
+		{""},
 		{"foo"},
-		{"foo."},
-		{"Foo\\"},
-		{"%"},
-		{"%%"},
-		{"%s"},
+		{"%v"},
 		{"%#v"},
+		{"%T"},
+		{"%%"},
+		{"%t"},
+		{"%b"},
+		{"%c"},
+		{"%d"},
+		{"%o"},
+		{"%q"},
+		{"%x"},
+		{"%X"},
+		{"%U"},
+		{"%b"},
+		{"%e"},
+		{"%E"},
+		{"%f"},
+		{"%F"},
+		{"%g"},
+		{"%G"},
+		{"%s"},
+		{"%q"},
+		{"%x"},
+		{"%X"},
+		{"%p"},
 	}
 
 	for _, noline := range []bool{false, true} {
 		for _, tt := range printSecretTests {
-			FprintSecret(w, tt.in, noline)
+			FprintSecret(&w, tt.in, noline)
+
+			actual := w.String()
+			expected := tt.in
+			if !noline {
+				expected += "\n"
+			}
+
+			if actual != expected {
+				t.Errorf("Expected: %s, Actual: %s", expected, actual)
+			}
+
+			w.Reset()
 		}
 	}
-
-	// Output:
-	// foo
-	// foo.
-	// Foo\
-	// %
-	// %%
-	// %s
-	// %#v
-	// foofoo.Foo\%%%%s%#v
 }

--- a/printer_test.go
+++ b/printer_test.go
@@ -1,6 +1,11 @@
 package unicreds
 
+import (
+	"os"
+)
+
 func ExamplePrintSecret() {
+	w := os.Stdout
 	var printSecretTests = []struct {
 		in string
 		// must manually specify output in Example tests
@@ -16,7 +21,7 @@ func ExamplePrintSecret() {
 
 	for _, noline := range []bool{false, true} {
 		for _, tt := range printSecretTests {
-			PrintSecret(tt.in, noline)
+			PrintSecret(w, tt.in, noline)
 		}
 	}
 

--- a/printer_test.go
+++ b/printer_test.go
@@ -1,4 +1,4 @@
-package main
+package unicreds
 
 func ExamplePrintSecret() {
 	var printSecretTests = []struct {
@@ -16,7 +16,7 @@ func ExamplePrintSecret() {
 
 	for _, noline := range []bool{false, true} {
 		for _, tt := range printSecretTests {
-			printSecret(tt.in, noline)
+			PrintSecret(tt.in, noline)
 		}
 	}
 

--- a/printer_test.go
+++ b/printer_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 )
 
-func ExamplePrintSecret() {
+func ExampleFprintSecret() {
 	w := os.Stdout
 	var printSecretTests = []struct {
 		in string
@@ -21,7 +21,7 @@ func ExamplePrintSecret() {
 
 	for _, noline := range []bool{false, true} {
 		for _, tt := range printSecretTests {
-			PrintSecret(w, tt.in, noline)
+			FprintSecret(w, tt.in, noline)
 		}
 	}
 


### PR DESCRIPTION
The error occurs in the [`printSecret` function](https://github.com/Versent/unicreds/blob/master/cmd/unicreds/main.go#L210-L217) when the `secret`
argument contains a `fmt` "verb" and the `noline` argument is set to
true.

```
func printSecret(secret string, noline bool) {
	log.WithField("noline", noline).Debug("print secret")
	if noline {
		fmt.Printf(secret) // secret parsed as format string
	} else {
		fmt.Println(secret)
	}
}
```

By using the `secret` argument as the first argument to `fmt.Printf` in
the `noline` branch of `printSecret`, `secret` is used as the format
specifier in `Printf`. Most possible inputs to `secret` will not see any
problems. With any input that happens to contain a `fmt` verb, however,
`Printf` will try to parse the input as containing verbs, then actually
format successive arguments to the function. As no successive arguments
are passed to `fmt.Printf`, the code reachs a "Too few arguments" error
case and produces incorrect output:

```
secret := mysupersecret%tlkajdsf
printSecret(secret, true)
=> mysupersecret%!t(MISSING)lkajdsf
```

More on `fmt` verbs and format errors:
https://golang.org/pkg/fmt/#hdr-Printing

More on `fmt.Printf`:
https://golang.org/pkg/fmt/#Printf