### PR TITLE
Fix printSecret bug when input contains fmt verb

### DIFF
--- a/cmd/unicreds/main.go
+++ b/cmd/unicreds/main.go
@@ -210,7 +210,7 @@ func printFatalError(err error) {
 func printSecret(secret string, noline bool) {
 	log.WithField("noline", noline).Debug("print secret")
 	if noline {
-		fmt.Printf(secret)
+		fmt.Print(secret)
 	} else {
 		fmt.Println(secret)
 	}


### PR DESCRIPTION
Replaces #73 per [recommendation](https://github.com/Versent/unicreds/pull/73#issuecomment-330134039) of @wolfeidau 

---

The error occurs in the `printSecret` function when the `secret`
argument contains a `fmt` "verb" and the `noline` argument is set to
true.

```
func printSecret(secret string, noline bool) {
	log.WithField("noline", noline).Debug("print secret")
	if noline {
		fmt.Printf(secret) // secret parsed as format string
	} else {
		fmt.Println(secret)
	}
}
```

By using the `secret` argument as the first argument to `fmt.Printf` in
the `noline` branch of `printSecret`, `secret` is used as the format
specifier in `Printf`. Most possible inputs to `secret` will not see any
problems. With any input that happens to contain a `fmt` verb, however,
`Printf` will try to parse the input as containing verbs, then actually
format successive arguments to the function. As no successive arguments
are passed to `fmt.Printf`, the code reachs a "Too few arguments" error
case and produces incorrect output:

```
secret := mysupersecret%tlkajdsf
printSecret(secret, true)
=> mysupersecret%!t(MISSING)lkajdsf
```

Use `Print` instead of `Printf` to avoid parsing the input string as a
fmt verb.

More on `fmt` verbs and format errors:
https://golang.org/pkg/fmt/#hdr-Printing

More on `fmt.Print`:
https://golang.org/pkg/fmt/#Print