### PR TITLE
Allow using AWS_PROFILE env variable in combination with ~/.aws/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,25 @@ Commands:
     Execute a command with all secrets loaded as environment variables.
 ```
 
+Unicreds supports the `AWS_*` environment variables, and configuration in `~/.aws/credentials` and `~/.aws/config`
+
 # examples
 
 * List secrets using default profile:
 ```
-$ unicreds -r us-west-2 list
+$ unicreds list
 ```
 
-* List secrets using profile MYPROFILE in `~/.aws/credentials` (NOTE: `~/.aws/config` is only used by aws CLI, not the SDK)
+* List secrets using the default profile, in a different region:
+```
+$ unicreds -r us-east-2 list
+$ AWS_REGION=us-east-2 unicreds list
+```
+
+* List secrets using profile MYPROFILE in `~/.aws/credentials` or `~/.aws/config`
 ```
 $ unicreds -r us-west-2 -p MYPROFILE list
+$ AWS_PROFILE=MYPROFILE unicreds list
 ```
 
 * List secrets using a profile, but also assuming a role:

--- a/aws_config.go
+++ b/aws_config.go
@@ -41,7 +41,7 @@ func SetAwsConfig(region, profile *string, role *string) (err error) {
 
 func setAwsConfig(region, profile *string, role *string) {
 	log.WithFields(log.Fields{"region": aws.StringValue(region), "profile": aws.StringValue(profile)}).Debug("Configure AWS")
-	config := &aws.Config{Region: region}
+	config := aws.Config{Region: region}
 
 	// if a profile is supplied then just use the shared credentials provider
 	// as per docs this will look in $HOME/.aws/credentials if the filename is ""
@@ -52,11 +52,16 @@ func setAwsConfig(region, profile *string, role *string) {
 	// Are we assuming a role?
 	if aws.StringValue(role) != "" {
 		// Must request credentials from STS service and replace before passing on
-		sess := session.Must(session.NewSession(config))
+		sts_sess := session.Must(session.NewSession(&config))
 		log.WithFields(log.Fields{"role": aws.StringValue(role)}).Debug("AssumeRole")
-		config.Credentials = stscreds.NewCredentials(sess, *role)
+		config.Credentials = stscreds.NewCredentials(sts_sess, *role)
 	}
 
-	SetDynamoDBConfig(config)
-	SetKMSConfig(config)
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		Config:            config,
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+
+	SetDynamoDBSession(sess)
+	SetKMSSession(sess)
 }

--- a/aws_config.go
+++ b/aws_config.go
@@ -25,10 +25,6 @@ func SetAwsConfig(region, profile *string, role *string) (err error) {
 		}
 	}
 
-	if aws.StringValue(region) == "" && aws.StringValue(profile) == "" {
-		return nil
-	}
-
 	// This is to work around a limitation of the credentials
 	// chain when providing an AWS profile as a flag
 	if aws.StringValue(region) == "" && aws.StringValue(profile) != "" {

--- a/ds.go
+++ b/ds.go
@@ -52,6 +52,10 @@ func SetDynamoDBConfig(config *aws.Config) {
 	dynamoSvc = dynamodb.New(session.New(), config)
 }
 
+func SetDynamoDBSession(sess *session.Session) {
+	dynamoSvc = dynamodb.New(sess)
+}
+
 // Credential managed credential information
 type Credential struct {
 	Name      string `dynamodbav:"name"`

--- a/kms.go
+++ b/kms.go
@@ -18,6 +18,10 @@ func SetKMSConfig(config *aws.Config) {
 	kmsSvc = kms.New(session.New(), config)
 }
 
+func SetKMSSession(sess *session.Session) {
+	kmsSvc = kms.New(sess)
+}
+
 // DataKey which contains the details of the KMS key
 type DataKey struct {
 	CiphertextBlob []byte


### PR DESCRIPTION
Similar to #65 and #70, this change allows users to use standard AWS command line flags with unicreds, and have the application read from `~/.aws/config`, so that configured profiles are available.

Allows

``` bash
unicreds list --region us-east-1 -t table -p root_profile -R arn:aws:iam::account_id:role/role_name
```

to be replaced with

``` bash
AWS_PROFILE=role_profile unicreds list --region us-east-1 -t table
```

Assuming that `role_profile` is configured in `~/.aws/config` with

``` ini
[profile role_profile]
role_arn = arn:aws:iam::account_id:role/role_name
source_profile = root_profile
```