### PR TITLE
Capitalize import to match github import name.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go:
     - 1.6
 #    - tip
 
-go_import_path: github.com/versent/unicreds
+go_import_path: github.com/Versent/unicreds
 
 install:
     - echo noop

--- a/cmd/unicreds/main.go
+++ b/cmd/unicreds/main.go
@@ -7,12 +7,12 @@ import (
 	"os/exec"
 	"syscall"
 
+	"github.com/Versent/unicreds"
+
+	"github.com/alecthomas/kingpin"
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
 	"github.com/apex/log/handlers/json"
-
-	"github.com/alecthomas/kingpin"
-	"github.com/versent/unicreds"
 )
 
 var (

--- a/ds_test.go
+++ b/ds_test.go
@@ -3,6 +3,8 @@ package unicreds
 import (
 	"testing"
 
+	"github.com/Versent/unicreds/mocks"
+
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/versent/unicreds/mocks"
 )
 
 var (

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -7,11 +7,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/Versent/unicreds"
+
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
-	"github.com/versent/unicreds"
 )
 
 func init() {


### PR DESCRIPTION
Had some issues with tools that are case sensitive and don't pickup a Github redirect.
This fixes them, not sure if it messes anything up for you, but if you are on a case sensitive system you would have to checkout with `go get github.com/Versent/unicreds`
