### PR TITLE
Migrate hmac to []byte and handle transition

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -5,7 +5,18 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 )
 
+// adjustHmac will force the hmac to be a byte array if present as string
+func adjustHmac(record map[string]*dynamodb.AttributeValue) {
+	if val, ok := record["hmac"]; ok {
+		if len(val.B) == 0 && val.S != nil {
+			val.B = []byte(*val.S)
+			val.S = nil
+		}
+	}
+}
+
 // Decode decode the supplied struct from the dynamodb result map
 func Decode(data map[string]*dynamodb.AttributeValue, rawVal interface{}) error {
+	adjustHmac(data)
 	return dynamodbattribute.UnmarshalMap(data, rawVal)
 }

--- a/encryptor.go
+++ b/encryptor.go
@@ -28,10 +28,13 @@ func Encrypt(key, plaintext []byte) ([]byte, error) {
 
 // ComputeHmac256 compute a hmac256 signature of the supplied message and return
 // the value hex encoded
-func ComputeHmac256(message, secret []byte) string {
+func ComputeHmac256(message, secret []byte) []byte {
 	h := hmac.New(sha256.New, secret)
 	h.Write(message)
-	return hex.EncodeToString(h.Sum(nil))
+	src := h.Sum(nil)
+	dst := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(dst, src)
+	return dst
 }
 
 // Decrypt AES encryption method which matches the pycrypto package


### PR DESCRIPTION
With more recent versions of credstash the hmac is stored in a binary format, which makes the unmarshaling fail.
This fixes the issue by forcing the entry retrieved to always be `[]byte`
Closes: #75 