### PR TITLE
Make the --profile flag use the shared config file

### DIFF
--- a/aws_config.go
+++ b/aws_config.go
@@ -37,27 +37,35 @@ func SetAwsConfig(region, profile *string, role *string) (err error) {
 
 func setAwsConfig(region, profile *string, role *string) {
 	log.WithFields(log.Fields{"region": aws.StringValue(region), "profile": aws.StringValue(profile)}).Debug("Configure AWS")
-	config := aws.Config{Region: region}
 
-	// if a profile is supplied then just use the shared credentials provider
-	// as per docs this will look in $HOME/.aws/credentials if the filename is ""
-	if aws.StringValue(profile) != "" {
-		config.Credentials = credentials.NewSharedCredentials("", *profile)
-	}
-
-	// Are we assuming a role?
-	if aws.StringValue(role) != "" {
-		// Must request credentials from STS service and replace before passing on
-		sts_sess := session.Must(session.NewSession(&config))
-		log.WithFields(log.Fields{"role": aws.StringValue(role)}).Debug("AssumeRole")
-		config.Credentials = stscreds.NewCredentials(sts_sess, *role)
-	}
-
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		Config:            config,
-		SharedConfigState: session.SharedConfigEnable,
-	}))
+	sess := getAwsSession(region, profile, role)
 
 	SetDynamoDBSession(sess)
 	SetKMSSession(sess)
+}
+
+func getAwsSession(region, profile, role *string) *session.Session {
+	config := aws.Config{Region: region}
+
+	// If a role is supplied, get credentials from STS Session
+	if aws.StringValue(role) != "" {
+		// If the role is being assumed through a non-default profile it must be added to the config.
+		// When an empty string is provided, it uses the default credentials file.
+		if aws.StringValue(profile) != "" {
+			config.Credentials = credentials.NewSharedCredentials("", *profile)
+		}
+
+		sts_session := session.Must(session.NewSession(&config))
+		log.WithFields(log.Fields{"role": aws.StringValue(role), "profile": aws.StringValue(profile)}).Debug("AssumeRole")
+		config.Credentials = stscreds.NewCredentials(sts_session, *role)
+
+		return session.Must(session.NewSession(&config))
+	}
+
+	// If no role is supplied, use the shared AWS config
+	return session.Must(session.NewSessionWithOptions(session.Options{
+		Config:            config,
+		SharedConfigState: session.SharedConfigEnable,
+		Profile:           *profile,
+	}))
 }

--- a/aws_config.go
+++ b/aws_config.go
@@ -34,7 +34,7 @@ func SetAwsConfig(region, profile *string, role *string) (err error) {
 	return nil
 }
 
-func setAwsConfig(region, profile *string, role *string) {
+func setAwsConfig(region, profile, role *string) {
 	log.WithFields(log.Fields{"region": aws.StringValue(region), "profile": aws.StringValue(profile)}).Debug("Configure AWS")
 
 	sess := getAwsSession(region, profile, role)
@@ -50,7 +50,7 @@ func getAwsSession(region, profile, role *string) *session.Session {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		Config:            config,
 		SharedConfigState: session.SharedConfigEnable,
-		Profile:           *profile,
+		Profile:           aws.StringValue(profile),
 	}))
 
 	// If a role is supplied, return a new session using STS-generated credentials


### PR DESCRIPTION
My last pull request did not actually work as advertised, using `unicreds --profile <a profile in ~/.aws/config>` would not load that profile.

This was because the profile flag was only being used to pull credentials from the default credentials file, ignoring the shared config file.

Using the `--profile` flag will now allow the use of any profile in the credentials or config file. If the `--role` flag is used, the assumed role session will be created using the shared config/profile configured session.