### PR TITLE
Fix golint fetch making tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - "PATH=/home/travis/gopath/bin:$PATH"
 
 script:
-    - go get -u github.com/golang/lint/golint
+    - go get -u golang.org/x/lint/golint
     - go get -u golang.org/x/tools/cmd/goimports
     - go get -u github.com/golang/dep/cmd/dep
     - golint ./...


### PR DESCRIPTION
Right now the builds fail with the following error:
```
$ go get -u github.com/golang/lint/golint
package github.com/golang/lint/golint: code in directory /home/travis/gopath/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
The command "go get -u github.com/golang/lint/golint" exited with 1.
```
The change in the url to `golang.org/x/lint/golint` fixes that issue.