### PR TITLE
Update to use AWS Metadata V2 API

### DIFF
--- a/aws_config.go
+++ b/aws_config.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	zoneURL = "http://169.254.169.254/latest/meta-data/placement/availability-zone"
+	tokenURL = "http://169.254.169.254/latest/api/token"
+	zoneURL  = "http://169.254.169.254/latest/meta-data/placement/availability-zone"
 )
 
 // SetAwsConfig configure the AWS region with a fallback for discovery


### PR DESCRIPTION
This  updates the unicreds package to use the AWS Instance Metadata Service (IMDS) version 2 when retrieving the region data.

The main change is in the getRegion function, which now includes an additional HTTP request to retrieve a token before accessing the instance metadata endpoint. This is in line with best practices for IMDSv2 and helps to enhance the security by requiring session-oriented requests.